### PR TITLE
feat: add universal adapter

### DIFF
--- a/packages/core/src/versionInfo.ts
+++ b/packages/core/src/versionInfo.ts
@@ -1,5 +1,5 @@
 
-const version = '1.1.55';
+const version = '1.1.57';
 const versionBuild = '2020-0101-1';
 
 export default {

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/consts.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/consts.ts
@@ -1,4 +1,4 @@
-enum WALLET_NAMES {
+export enum WALLET_NAMES {
   metamask = 'metamask',
   unisat = 'unisat',
   phantom = 'phantom',

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/index.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/index.ts
@@ -50,5 +50,4 @@ import './sites/synapseprotocol';
 import './sites/stargateFinance';
 import './sites/link3';
 import './sites/benqi';
-
 import './universal/index';

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/index.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/index.ts
@@ -50,3 +50,5 @@ import './sites/synapseprotocol';
 import './sites/stargateFinance';
 import './sites/link3';
 import './sites/benqi';
+
+import './universal/index';

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/config.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/config.ts
@@ -32,6 +32,11 @@ export const basicWalletInfo = {
     updatedName: WALLET_CONNECT_INFO.unisat.text,
     name: /^(unisat|Unisat Wallet)$/i,
   },
+  [WALLET_NAMES.tronlink]: {
+    updatedIcon: WALLET_CONNECT_INFO.tronlink.icon,
+    updatedName: WALLET_CONNECT_INFO.tronlink.text,
+    name: /^tronlink$/i,
+  },
 } as const;
 
 /**
@@ -445,6 +450,22 @@ export const sitesConfig: SitesInfo[] = [
                   e.innerText.includes('BTC wallets')
                 );
               },
+            );
+          },
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.justlend.org'],
+    walletsForProvider: {
+      [IInjectedProviderNames.btc]: [
+        {
+          ...basicWalletInfo['tronlink'],
+          container: () => {
+            return getConnectWalletModalByTitle(
+              'div.connect-modal-v2.entry-modal-v2',
+              'Connect Wallet',
             );
           },
         },

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/config.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/config.ts
@@ -1,0 +1,379 @@
+import { IInjectedProviderNames } from '@onekeyfe/cross-inpage-provider-types';
+import { WALLET_CONNECT_INFO } from '../consts';
+import { replaceIcon } from './imgUtils';
+import { findIconAndNameInShadowRoot } from './shadowRoot';
+import { FindResultType, Selector } from './type';
+import { getConnectWalletModalByTitle, getWalletListByBtn } from './utils';
+import { findIconAndNameDirectly } from './findIconAndName';
+
+export const basicWalletInfo = {
+  metamask: {
+    updatedIcon: WALLET_CONNECT_INFO.metamask.icon,
+    updatedName: WALLET_CONNECT_INFO.metamask.text,
+    name: /^meta\s*mask$/i,
+  },
+  walletconnect: {
+    updatedIcon: WALLET_CONNECT_INFO.walletconnect.icon,
+    updatedName: WALLET_CONNECT_INFO.walletconnect.text,
+    name: /^wallet\s*connect$/i,
+  },
+  suiwallet: {
+    updatedIcon: WALLET_CONNECT_INFO.suiwallet.icon,
+    updatedName: WALLET_CONNECT_INFO.suiwallet.text,
+    name: /^(sui|Sui\s?Wallet)$/i,
+  },
+  phantom: {
+    updatedIcon: WALLET_CONNECT_INFO.phantom.icon,
+    updatedName: WALLET_CONNECT_INFO.phantom.text,
+    name: /^phantom$/i,
+  },
+} as const;
+
+/**
+ *  used to the following conditions:
+ *    - wallet icon and name both exists
+ *    - only one icon and only one name element
+ * 
+ * wallet icon and name locate strategy:
+ *  step1: if icon and name elements have uniq and stable class name ,
+ *     - then use function `findIconAndName()` to return them directly
+ *  step2: else use `container` to locate the name and icon automatically
+ */
+
+export type WalletInfo = {
+  updatedIcon: string;
+  updatedName: string;
+  /**
+   * it's better to  match the start and the end character at the same time
+   */
+  name: RegExp;
+
+  /**
+   * 1. the common ancestor selector of wallet icon and name element
+   * 2. get the container element by document.querySelector(not document.querySelectorAll)
+   * 3. tradeoff
+   *    3.1. if the selector is ID selector(or any unique and stable selector,like '.connect-wallet-modal')
+   *      - The closer the selector is to the wallet button, the more likely to get element.
+   *          - because only one element will be choosen
+   *      - but the closer the selector is to the wallet button, the more difficult to maintain .
+   *      - there is no difference between the accuracy that mean it will not choose the wrong element.
+   *          - because only one element will be choosen
+   *    3.2. if the selector is not a unique or stable selector, like '.modal'
+   *      - The farther away from the wallet button, the more likely to get the wrong element.
+   *          - beacuase '.modal' will choose other modal elements which are not connect wallet modal
+   * 4. choose strategy :
+   *    step1. choose the wallet button by unique and stable selector(id selector,uniq class etc) if possible
+   *    step2. choose the wallet button list container by unique and stable selector(id selector,uniq class etc) if possible
+   *    step3. choose the connect wallet modal by title [getConnectWalletModalByTitle()]
+   * 5. the container must be a selector or a function for it should be called when mutation happens
+   */
+  container?: Selector | (() => HTMLElement | null);
+
+
+  /**
+   *  custom method used when
+   *  1. icon and name have a uniq selector(id selector,uniq class etc)
+   *  2. other special cases,like shadowRoot
+   * **/
+  findIconAndName?: (wallet: WalletInfo) => FindResultType | undefined;
+
+  updateIcon?: (img: HTMLElement, iconStr: string) => HTMLImageElement;
+  updateName?: (textNode: Text, text: string) => void;
+};
+
+export type SitesInfo = {
+  urls: string[];
+  walletsForProvider: {
+    [k in IInjectedProviderNames]?: WalletInfo[];
+  };
+};
+
+export const sitesConfig: SitesInfo[] = [
+  {
+    urls: ['app.turbos.finance'],
+    walletsForProvider: {
+      [IInjectedProviderNames.sui]: [
+        {
+          ...basicWalletInfo['suiwallet'],
+          container: "div[role='dialog'] .rc-dialog-body > ul",
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.defisaver.com'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          findIconAndName({ name }) {
+            return findIconAndNameDirectly(
+              '.button-option.MetaMask > svg',
+              '.button-option.MetaMask .connect-wallet-button-name',
+              name,
+            );
+          },
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          findIconAndName({ name }) {
+            return findIconAndNameDirectly(
+              '.button-option.WalletConnect > svg',
+              '.button-option.WalletConnect .connect-wallet-button-name',
+              name,
+            );
+          },
+        },
+      ],
+    },
+  },
+  {
+    urls: ['haedal.xyz'],
+    walletsForProvider: {
+      [IInjectedProviderNames.sui]: [
+        {
+          ...basicWalletInfo['suiwallet'],
+          container: "div[role='dialog'] .wkit-select__container",
+        },
+      ],
+    },
+  },
+
+  {
+    urls: ['trade.bluefin.io'],
+    walletsForProvider: {
+      [IInjectedProviderNames.sui]: [
+        {
+          ...basicWalletInfo['suiwallet'],
+          name: /^Connect Sui Wallet$/,
+          container: () => getWalletListByBtn("div[role='dialog'] [data-testid='connect-wallet']"),
+          updateIcon: (originnalNode: HTMLElement, iconSrc: string) => {
+            const img = replaceIcon(originnalNode, iconSrc);
+            img.style.marginRight = '12px';
+            return img;
+          },
+        },
+      ],
+    },
+  },
+  {
+    urls: ['omnilending.omnibtc.finance'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: "div[role='dialog'] .ant-modal-content .wallets-inner",
+        },
+      ],
+      [IInjectedProviderNames.sui]: [
+        {
+          ...basicWalletInfo['suiwallet'],
+          container: "div[role='dialog'] [class*='WalletListWrapper']",
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.venus.io'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: () =>
+            getConnectWalletModalByTitle('div.MuiModal-root .venus-modal', 'Connect a wallet'),
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: () =>
+            getConnectWalletModalByTitle('div.MuiModal-root .venus-modal', 'Connect a wallet'),
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.uncx.network'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: () => getWalletListByBtn("div[role='dialog'] .v-card .c-list"),
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: () => getWalletListByBtn("div[role='dialog'] .v-card .c-list"),
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.benqi.fi'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: '#metamask',
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: '#wallet-connect',
+        },
+      ],
+    },
+  },
+  {
+    urls: ['manta.layerbank.finance'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: () => getConnectWalletModalByTitle('div.MuiModal-root', 'Connect Wallet'),
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: () => getConnectWalletModalByTitle('div.MuiModal-root', 'Connect Wallet'),
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.orbitlending.io'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: 'button[data-testid="rk-wallet-option-metaMask"]',
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: 'button[data-testid="rk-wallet-option-walletConnect"]',
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.stakewise.io'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: '[data-testid="metaMask-connector-button"]',
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: '[data-testid="walletConnect-connector-button"]',
+        },
+      ],
+    },
+  },
+  {
+    urls: ['aerodrome.finance'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: '.bg-connect button[type="button"]:nth-child(2)',
+        },
+      ],
+    },
+  },
+  {
+    urls: ['lista.org'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: 'div.MuiModal-root[role="presentation"] [class*="walletGroup"]',
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: 'div.MuiModal-root[role="presentation"] [class*="walletGroup"] ',
+        },
+      ],
+    },
+  },
+
+  //shadow root
+  {
+    urls: ['app.prismafinance.com'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: '.modal .outer-container div.wallets-container ',
+          findIconAndName: ({ container, name }) => {
+            return findIconAndNameInShadowRoot('onboard-v2', container as string, name);
+          },
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: '.modal .outer-container div.wallets-container ',
+          findIconAndName: ({ container, name }) => {
+            return findIconAndNameInShadowRoot('onboard-v2', container as string, name);
+          },
+        },
+      ],
+    },
+  },
+  {
+    urls: ['vvs.finance'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: '#wallet-connect-metamask',
+        },
+      ],
+    },
+  },
+  {
+    urls: ['raydium.io'],
+    walletsForProvider: {
+      [IInjectedProviderNames.solana]: [
+        {
+          ...basicWalletInfo['phantom'],
+          container: '.Dialog .Card .grid.grid-cols-2',
+        },
+      ],
+    },
+  },
+  {
+    urls: ['01.xyz'],
+    walletsForProvider: {
+      [IInjectedProviderNames.solana]: [
+        {
+          ...basicWalletInfo['phantom'],
+          container: () => getConnectWalletModalByTitle('div.fixed', 'Select Wallet'),
+        },
+      ],
+    },
+  },
+  {
+    urls: ['francium.io'],
+    walletsForProvider: {
+      [IInjectedProviderNames.solana]: [
+        {
+          ...basicWalletInfo['phantom'],
+          container: '.wallet-modal .connect-wallet-list',
+        },
+      ],
+    },
+  },
+  
+  {
+    urls: ['defi.instadapp.io'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: '#WEB3_CONNECT_MODAL_ID .web3modal-modal-card',
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          name: /^WalletConnect v2$/,
+          container: '#WEB3_CONNECT_MODAL_ID .web3modal-modal-card',
+        },
+      ],
+      
+    },
+  },
+];

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/config.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/config.ts
@@ -37,6 +37,21 @@ export const basicWalletInfo = {
     updatedName: WALLET_CONNECT_INFO.tronlink.text,
     name: /^tronlink$/i,
   },
+  [WALLET_NAMES.petra]: {
+    updatedIcon: WALLET_CONNECT_INFO.petra.icon,
+    updatedName: WALLET_CONNECT_INFO.petra.text,
+    name: /^Petra$/i,
+  },
+  [WALLET_NAMES.keplr]: {
+    updatedIcon: WALLET_CONNECT_INFO.keplr.icon,
+    updatedName: WALLET_CONNECT_INFO.keplr.text,
+    name: /^Keplr$/i,
+  },
+  [WALLET_NAMES.polkadot]: {
+    updatedIcon: WALLET_CONNECT_INFO.polkadot.icon,
+    updatedName: WALLET_CONNECT_INFO.polkadot.text,
+    name: /^(Polkadot|polkadot\.js)$/i,
+  },
 } as const;
 
 /**
@@ -466,6 +481,227 @@ export const sitesConfig: SitesInfo[] = [
             return getConnectWalletModalByTitle(
               'div.connect-modal-v2.entry-modal-v2',
               'Connect Wallet',
+            );
+          },
+        },
+      ],
+    },
+  },
+  {
+    urls: ['sun.io'],
+    walletsForProvider: {
+      [IInjectedProviderNames.btc]: [
+        {
+          ...basicWalletInfo['tronlink'],
+          container: () => {
+            return getConnectWalletModalByTitle('div.wallet-modal', 'Connect Wallet');
+          },
+        },
+      ],
+    },
+  },
+  {
+    urls: ['www.team.finance'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: () => {
+            return getConnectWalletModalByTitle('.fixed[role="dialog"]', 'Select wallet');
+          },
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: () => {
+            return getConnectWalletModalByTitle('.fixed[role="dialog"]', 'Select wallet');
+          },
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.thala.fi'],
+    walletsForProvider: {
+      [IInjectedProviderNames.aptos]: [
+        {
+          ...basicWalletInfo['petra'],
+          container: () => {
+            return getConnectWalletModalByTitle('div.chakra-modal__body', 'Welcome to Thala');
+          },
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.kinza.finance'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: 'button[data-testid="rk-wallet-option-metaMask"]',
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: 'button[data-testid="rk-wallet-option-walletConnect"]',
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.osmosis.zone'],
+    walletsForProvider: {
+      [IInjectedProviderNames.cosmos]: [
+        {
+          ...basicWalletInfo['keplr'],
+          findIconAndName({ name }) {
+            return findIconAndNameDirectly(
+              '.ReactModalPortal button img[alt="Wallet logo"][src*="keplr"]',
+              (icon: HTMLElement) => icon.parentElement,
+              name,
+            );
+          },
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.gearbox.fi'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: 'button[data-testid="wallet-select-dialog-wallet-metamask"]',
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: 'button[data-testid="wallet-select-dialog-wallet-walletconnect"]',
+        },
+      ],
+    },
+  },
+  {
+    urls: ['blur.io'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: 'button[id="METAMASK"]',
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: 'button[id="WALLETCONNECT"]',
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.stride.zone'],
+    walletsForProvider: {
+      [IInjectedProviderNames.cosmos]: [
+        {
+          ...basicWalletInfo['keplr'],
+          container: () => {
+            return getConnectWalletModalByTitle('div[role="dialog"]', 'Select a wallet');
+          },
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.manta.network'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          findIconAndName({ name }) {
+            return findIconAndNameDirectly(
+              '.relative.rounded-2xl.text-default svg.rounded-full',
+              (icon: HTMLElement) => icon.parentElement,
+              name,
+            );
+          },
+        },
+      ],
+      [IInjectedProviderNames.polkadot]: [
+        {
+          ...basicWalletInfo['polkadot'],
+          findIconAndName: ({ name }) => {
+            return findIconAndNameDirectly(
+              '.relative.rounded-2xl.text-default img[alt="Polkadotjs Logo"]',
+              (icon: HTMLElement) => icon.parentElement,
+              name,
+            );
+          },
+        },
+      ],
+    },
+  },
+  {
+    urls: ['www.metapool.app'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: 'button[data-testid="rk-wallet-option-metaMask"]',
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: 'button[data-testid="rk-wallet-option-walletConnect"]',
+        },
+      ],
+    },
+  },
+  {
+    urls: ['app.arrakis.fi'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: 'button[data-testid="rk-wallet-option-metaMask"]',
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: 'button[data-testid="rk-wallet-option-walletConnect"]',
+        },
+      ],
+    },
+  },
+  {
+    urls: ['tectonic.finance'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          container: () => getConnectWalletModalByTitle('#headlessui-dialog-1', 'Connect Wallet'),
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          container: () => getConnectWalletModalByTitle('#headlessui-dialog-1', 'Connect Wallet'),
+        },
+      ],
+    },
+  },
+  {
+    urls: ['quickswap.exchange'],
+    walletsForProvider: {
+      [IInjectedProviderNames.ethereum]: [
+        {
+          ...basicWalletInfo['metamask'],
+          findIconAndName({ name }) {
+            return findIconAndNameDirectly(
+              '#connect-METAMASK img',
+              '#connect-METAMASK div.optionHeader',
+              name,
+            );
+          },
+        },
+        {
+          ...basicWalletInfo['walletconnect'],
+          findIconAndName({ name }) {
+            return findIconAndNameDirectly(
+              '#connect-WALLET_CONNECT img',
+              '#connect-WALLET_CONNECT div.optionHeader',
+              name,
             );
           },
         },

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/consts.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/consts.ts
@@ -1,0 +1,5 @@
+export const MAX_LEVELS = 4;
+export const DISTNACE_BETWEEN_ICON_AND_TEXT = 100;
+export const ICON_MAX_SIZE = 150;
+export const ICON_MIN_SIZE = 10;
+export const ALIGN_THRESHOLD = 40;

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/findIconAndName.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/findIconAndName.ts
@@ -1,0 +1,72 @@
+import { findWalletIconByParent, isWalletIcon } from './imgUtils';
+import { findWalletText } from './textUtils';
+import { FindResultType, Selector } from './type';
+import { dbg, isClickable, isInExternalLink } from './utils';
+
+/**
+ *
+ * @description:
+ *   don't document to querySelector because it maybe not work in shadowRoot,
+ *   instead of it, use the containerElement
+ */
+export function findIconAndNameByParent(
+  containerElement: HTMLElement,
+  walletName: RegExp,
+): FindResultType | undefined {
+  const textNode = findWalletText(containerElement, walletName);
+  if (!textNode || !textNode.parentElement) {
+    dbg(`===>not find wallet name text node`);
+    return;
+  }
+  if (
+    !isClickable(textNode.parentElement) ||
+    isInExternalLink(textNode.parentElement, containerElement)
+  ) {
+    dbg(`===>it is not clickable or is in external link`);
+    return;
+  }
+  dbg(`===>find wallet name text node`);
+
+  let parent: HTMLElement | null = textNode.parentElement;
+  let iconNode: HTMLImageElement | HTMLElement | undefined = undefined;
+
+  while (parent && parent !== containerElement?.parentElement) {
+    const walletIcon = findWalletIconByParent(parent, textNode);
+    if (!walletIcon) {
+      parent = parent.parentElement;
+      continue;
+    }
+    iconNode = walletIcon;
+    break;
+  }
+  if (!iconNode) {
+    return;
+  }
+  // make sure the icon and text are both existed
+  return { iconNode, textNode };
+}
+
+export function findIconAndNameDirectly(
+  iconSelector: Selector | (() => HTMLElement),
+  textSelector: Selector | (() => HTMLElement),
+  name: RegExp,
+  container = document,
+): FindResultType | undefined {
+  const iconElement =
+    typeof iconSelector === 'string'
+      ? container.querySelector<HTMLElement>(iconSelector)
+      : iconSelector();
+  const textElement =
+    typeof textSelector === 'string'
+      ? container.querySelector<HTMLElement>(textSelector)
+      : textSelector();
+  const textNode = textElement && findWalletText(textElement, name);
+  if (!iconElement || !textNode) {
+    return undefined;
+  }
+  return {
+    iconNode: iconElement,
+    textNode,
+  };
+}
+

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/findIconAndName.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/findIconAndName.ts
@@ -1,3 +1,4 @@
+import { MAX_LEVELS } from './consts';
 import { findWalletIconByParent, isWalletIcon } from './imgUtils';
 import { findWalletText } from './textUtils';
 import { FindResultType, Selector } from './type';
@@ -15,7 +16,7 @@ export function findIconAndNameByParent(
 ): FindResultType | undefined {
   const textNode = findWalletText(containerElement, walletName);
   if (!textNode || !textNode.parentElement) {
-    dbg(`===>not find wallet name text node`);
+    dbg(`===>no wallet name text node found`);
     return;
   }
   if (
@@ -25,12 +26,12 @@ export function findIconAndNameByParent(
     dbg(`===>it is not clickable or is in external link`);
     return;
   }
-  dbg(`===>find wallet name text node`);
 
   let parent: HTMLElement | null = textNode.parentElement;
   let iconNode: HTMLImageElement | HTMLElement | undefined = undefined;
 
-  while (parent && parent !== containerElement?.parentElement) {
+  let level = 0;
+  while (parent && parent !== containerElement?.parentElement && level++ < MAX_LEVELS) {
     const walletIcon = findWalletIconByParent(parent, textNode);
     if (!walletIcon) {
       parent = parent.parentElement;
@@ -40,6 +41,7 @@ export function findIconAndNameByParent(
     break;
   }
   if (!iconNode) {
+    dbg(`===>no wallet icon node found`);
     return;
   }
   // make sure the icon and text are both existed
@@ -64,7 +66,7 @@ export function findIconAndNameDirectly(
       );
     }
   }
-  
+
   const textElement =
     typeof textSelector === 'string'
       ? container.querySelector<HTMLElement>(textSelector)

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/imgUtils.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/imgUtils.ts
@@ -1,5 +1,5 @@
 import { ICON_MAX_SIZE, ICON_MIN_SIZE } from './consts';
-import { dbg, isAlign, isClickable } from './utils';
+import { dbg, isClickable } from './utils';
 
 export function replaceIcon(originalNode: HTMLElement, newIconSrc: string) {
   if (originalNode instanceof HTMLImageElement) {

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/imgUtils.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/imgUtils.ts
@@ -1,0 +1,68 @@
+import { ICON_MAX_SIZE, ICON_MIN_SIZE } from './consts';
+import { dbg, isAlign, isClickable } from './utils';
+
+export function replaceIcon(originalNode: HTMLElement, newIconSrc: string) {
+  if (originalNode instanceof HTMLImageElement) {
+    originalNode.src = newIconSrc;
+    originalNode.removeAttribute('srcset');
+    return originalNode;
+  } else {
+    const imgNode = createImageEle(newIconSrc);
+    const style = window.getComputedStyle(originalNode);
+    imgNode.style.width = style.width;
+    imgNode.style.height = style.height;
+    imgNode.classList.add(...Array.from(originalNode.classList));
+    originalNode.replaceWith(imgNode);
+    return imgNode;
+  }
+}
+
+export function createImageEle(src: string) {
+  const img = new Image();
+  img.src = src;
+  img.style.maxWidth = '100%';
+  img.style.maxHeight = '100%';
+  return img;
+}
+
+export function findIconNodesByParent(parent: HTMLElement) {
+  const walker = document.createTreeWalker(parent, NodeFilter.SHOW_ELEMENT, {
+    acceptNode(node) {
+      const hasBgImg = window.getComputedStyle(node as HTMLElement).backgroundImage !== 'none';
+      return node.nodeName === 'IMG' || hasBgImg || node.nodeName === 'svg'
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_SKIP;
+    },
+  });
+  const matchingNodes: HTMLElement[] = [];
+  while (walker.nextNode()) {
+    matchingNodes.push(walker.currentNode as HTMLElement);
+  }
+  return matchingNodes;
+}
+/**
+ * @description:
+ * make sure that there is only one icon node match walletIcon to ignore hidden icon and other icon
+ */
+export function findWalletIconByParent(parent: HTMLElement, textNode: Text) {
+  const iconNodes = findIconNodesByParent(parent);
+  if (iconNodes.length > 1) {
+    return;
+  }
+  const icon = iconNodes[0];
+  if (!icon || !textNode.parentElement || !isWalletIcon(icon, textNode.parentElement)) {
+    dbg(`===>${icon?.tagName || ''} it is not a wallet icon`);
+    return;
+  }
+  return icon;
+}
+
+export function isWalletIcon(walletIcon: HTMLElement, textNode: HTMLElement) {
+  const { width, height } = walletIcon.getBoundingClientRect();
+  const isSizeMatch =
+    width < ICON_MAX_SIZE &&
+    width > ICON_MIN_SIZE &&
+    height < ICON_MAX_SIZE &&
+    height > ICON_MIN_SIZE;
+  return isClickable(walletIcon) && isSizeMatch;
+}

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/index.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/index.ts
@@ -32,37 +32,40 @@ function hackWalletConnectButton(sites: SitesInfo[]) {
                 updateIcon = defaultReplaceIcon,
                 updateName = defaultReplaceText,
               } = wallet;
-              const walletId = `${provider}-${updatedName.replace(/[\s&]/g, '').toLowerCase()}`;
-              const hasReplaced = !!document.querySelector(`.${walletId}`);
-              dbg('walletId', walletId);
-              if (hasReplaced) {
-                continue;
-              }
-
-              let result: FindResultType | undefined;
-              if (findIconAndName) {
-                result = findIconAndName.call(null, wallet);
-              } else if (container) {
-                const isSelector = typeof container === 'string';
-                const containerElement: HTMLElement | null = isSelector
-                  ? document.querySelector(container)
-                  : container();
-                if (!containerElement) {
+              try {
+                const walletId = `${provider}-${updatedName.replace(/[\s&]/g, '').toLowerCase()}`;
+                const hasReplaced = !!document.querySelector(`.${walletId}`);
+                dbg('walletId', walletId);
+                if (hasReplaced) {
                   continue;
                 }
-                result = defaultFindIconAndName(containerElement, name);
-              }
-              if (!result) {
-                dbg('no result found');
-                continue;
-              }
-              const { textNode, iconNode } = result;
-              if (textNode && iconNode) {
-                updateName(textNode, updatedName);
-                const newIconElement = updateIcon(iconNode, updatedIcon);
-                newIconElement.classList.add(walletId);
-                dbg('textNode', textNode);
-                dbg('iconNode', iconNode);
+                let result: FindResultType | undefined;
+                if (findIconAndName) {
+                  result = findIconAndName.call(null, wallet);
+                } else if (container) {
+                  const isSelector = typeof container === 'string';
+                  const containerElement: HTMLElement | null = isSelector
+                    ? document.querySelector(container)
+                    : container();
+                  if (!containerElement) {
+                    continue;
+                  }
+                  result = defaultFindIconAndName(containerElement, name);
+                }
+                if (!result) {
+                  dbg('no result found');
+                  continue;
+                }
+                const { textNode, iconNode } = result;
+                if (textNode && iconNode) {
+                  updateName(textNode, updatedName);
+                  const newIconElement = updateIcon(iconNode, updatedIcon);
+                  newIconElement.classList.add(walletId);
+                  dbg('textNode', textNode);
+                  dbg('iconNode', iconNode);
+                }
+              } catch (e) {
+                dbg(e);
               }
             }
           }

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/index.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/index.ts
@@ -1,0 +1,79 @@
+import { IInjectedProviderNames } from '@onekeyfe/cross-inpage-provider-types';
+import { hackConnectButton } from '../hackConnectButton';
+import { SitesInfo, sitesConfig } from './config';
+import { findIconAndNameByParent as defaultFindIconAndName } from './findIconAndName';
+import { replaceIcon as defaultReplaceIcon } from './imgUtils';
+import { replaceText as defaultReplaceText } from './textUtils';
+import { FindResultType } from './type';
+import { dbg } from './utils';
+
+function hackWalletConnectButton(sites: SitesInfo[]) {
+  for (const site of sites) {
+    const { urls, walletsForProvider } = site;
+    const providers = Object.keys(walletsForProvider) as IInjectedProviderNames[];
+    hackConnectButton({
+      urls,
+      providers,
+      replaceMethod(
+        { providers: enabledProviders }: { providers: IInjectedProviderNames[] } = {
+          providers: [],
+        },
+      ) {
+        for (const provider of providers) {
+          if (enabledProviders.includes(provider)) {
+            const wallets = walletsForProvider[provider] || [];
+            for (const wallet of wallets) {
+              const {
+                updatedIcon,
+                updatedName,
+                name,
+                findIconAndName,
+                container,
+                updateIcon = defaultReplaceIcon,
+                updateName = defaultReplaceText,
+              } = wallet;
+              const walletId = `${provider}-${updatedName.replace(/[\s&]/g, '').toLowerCase()}`;
+              const hasReplaced = !!document.querySelector(`.${walletId}`);
+              dbg('walletId', walletId);
+              if (hasReplaced) {
+                continue;
+              }
+
+              let result: FindResultType | undefined;
+              if (findIconAndName) {
+                result = findIconAndName.call(null, wallet);
+              } else if (container) {
+                const isSelector = typeof container === 'string';
+                const containerElement: HTMLElement | null = isSelector
+                  ? document.querySelector(container)
+                  : container();
+                if (!containerElement) {
+                  continue;
+                }
+                result = defaultFindIconAndName(containerElement, name);
+              }
+              if (!result) {
+                dbg('no result found');
+                continue;
+              }
+              const { textNode, iconNode } = result;
+              if (textNode && iconNode) {
+                updateName(textNode, updatedName);
+                const newIconElement = updateIcon(iconNode, updatedIcon);
+                newIconElement.classList.add(walletId);
+                dbg('textNode', textNode);
+                dbg('iconNode', iconNode);
+              }
+            }
+          }
+        }
+      },
+    });
+  }
+}
+
+try {
+  hackWalletConnectButton(sitesConfig);
+} catch (e) {
+  console.log(e);
+}

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/shadowRoot.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/shadowRoot.ts
@@ -1,0 +1,18 @@
+import { FindResultType, Selector } from './type';
+import { findIconAndNameByParent } from './findIconAndName';
+
+export function findIconAndNameInShadowRoot(
+  hostSelector: Selector,
+  containerSelector: Selector,
+  walletName: RegExp,
+): FindResultType | undefined {
+  const shadowRoot = document.querySelector(hostSelector)?.shadowRoot;
+  if (!shadowRoot) {
+    return;
+  }
+  const containerElement = shadowRoot.querySelector(containerSelector) as HTMLElement | undefined;
+  if (!containerElement) {
+    return;
+  }
+  return findIconAndNameByParent(containerElement, walletName);
+}

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/textUtils.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/textUtils.ts
@@ -1,0 +1,24 @@
+import domUtils from '../utils/utilsDomNodes';
+import { dbg } from './utils';
+
+export function makeTextEllipse(textNode: HTMLElement) {
+  textNode.style.whiteSpace = 'nowrap';
+  textNode.style.overflow = 'hidden';
+  textNode.style.textOverflow = 'ellipsis';
+}
+
+export function replaceText(textNode: Text, newText: string) {
+  textNode.replaceWith(newText);
+}
+/**
+ * @description:
+ * make sure there is only one text node match walletName to ignore hidden text and other text
+ */
+export function findWalletText(container: HTMLElement, walletName: RegExp): Text | null {
+  const textNodes = domUtils.findTextNode(container, walletName, 'all') as Text[] | null;
+  if (!textNodes || textNodes?.length > 1) {
+    dbg(`===>find none or more than one text node for wallet name`);
+    return null;
+  }
+  return textNodes[0];
+}

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/type.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/type.ts
@@ -1,0 +1,5 @@
+export type Selector = string;
+export type FindResultType = {
+  iconNode: HTMLElement;
+  textNode: Text;
+};

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/utils.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/utils.ts
@@ -1,4 +1,3 @@
-import { ALIGN_THRESHOLD } from './consts';
 import { Selector } from './type';
 
 export const isProd = process.env.NODE_ENV === 'production';
@@ -15,18 +14,24 @@ export function isClickable(ele: HTMLElement) {
 export const getWalletListByBtn = (anyButtonSelector: Selector) => {
   const ele = document.querySelector(anyButtonSelector);
   if (!ele || !ele.parentElement) {
-    throw new Error(`[universal]: can not find the wallet button list`);
+    dbg(`can not find the wallet button list`);
+    return null;
   }
   return ele.parentElement;
 };
-export const getConnectWalletModalByTitle = (modalSelector: Selector, title: string) => {
+export const getConnectWalletModalByTitle = (
+  modalSelector: Selector,
+  title: string,
+  filter?: (modal: HTMLElement) => boolean,
+) => {
   const eles = Array.from(document.querySelectorAll<HTMLElement>(modalSelector));
   for (const ele of eles) {
-    if (ele.innerText.includes(title)) {
+    if (filter ? filter(ele) : true && ele.innerText.includes(title)) {
       return ele;
     }
   }
-  throw new Error(`[universal]: can not find the connect wallet modal`);
+  dbg('can not find the connect wallet modal');
+  return null;
 };
 
 export function isInExternalLink(element: HTMLElement, container: HTMLElement) {
@@ -37,12 +42,4 @@ export function isInExternalLink(element: HTMLElement, container: HTMLElement) {
     element = element.parentNode as HTMLElement;
   }
   return false;
-}
-
-export function isAlign(ele1: HTMLElement, ele2: HTMLElement) {
-  const rect1 = ele1.getBoundingClientRect();
-  const rect2 = ele2.getBoundingClientRect();
-  const dx = Math.abs(rect1.left - rect2.left);
-  const dy = Math.abs(rect1.top - rect2.top);
-  return dx < ALIGN_THRESHOLD || dy < ALIGN_THRESHOLD;
 }

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/utils.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/utils.ts
@@ -1,0 +1,48 @@
+import { ALIGN_THRESHOLD } from './consts';
+import { Selector } from './type';
+
+export const isProd = process.env.NODE_ENV === 'production';
+export const dbg = (...args: unknown[]) => {
+  if (!isProd) {
+    console.log('[universal]:', ...args);
+  }
+};
+
+export function isClickable(ele: HTMLElement) {
+  return ele && window.getComputedStyle(ele).cursor === 'pointer';
+}
+
+export const getWalletListByBtn = (anyButtonSelector: Selector) => {
+  const ele = document.querySelector(anyButtonSelector);
+  if (!ele || !ele.parentElement) {
+    throw new Error(`[universal]: can not find the wallet button list`);
+  }
+  return ele.parentElement;
+};
+export const getConnectWalletModalByTitle = (modalSelector: Selector, title: string) => {
+  const eles = Array.from(document.querySelectorAll<HTMLElement>(modalSelector));
+  for (const ele of eles) {
+    if (ele.innerText.includes(title)) {
+      return ele;
+    }
+  }
+  throw new Error(`[universal]: can not find the connect wallet modal`);
+};
+
+export function isInExternalLink(element: HTMLElement, container: HTMLElement) {
+  while (element !== container) {
+    if (element.tagName === 'A') {
+      return true;
+    }
+    element = element.parentNode as HTMLElement;
+  }
+  return false;
+}
+
+export function isAlign(ele1: HTMLElement, ele2: HTMLElement) {
+  const rect1 = ele1.getBoundingClientRect();
+  const rect2 = ele2.getBoundingClientRect();
+  const dx = Math.abs(rect1.left - rect2.left);
+  const dy = Math.abs(rect1.top - rect2.top);
+  return dx < ALIGN_THRESHOLD || dy < ALIGN_THRESHOLD;
+}

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/utils.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/universal/utils.ts
@@ -26,7 +26,7 @@ export const getConnectWalletModalByTitle = (
 ) => {
   const eles = Array.from(document.querySelectorAll<HTMLElement>(modalSelector));
   for (const ele of eles) {
-    if (filter ? filter(ele) : true && ele.innerText.includes(title)) {
+    if (isVisible(ele) && filter ? filter(ele) : true && ele.innerText.includes(title)) {
       return ele;
     }
   }
@@ -42,4 +42,8 @@ export function isInExternalLink(element: HTMLElement, container: HTMLElement) {
     element = element.parentNode as HTMLElement;
   }
   return false;
+}
+export function isVisible(ele: HTMLElement) {
+  const style = window.getComputedStyle(ele);
+  return style.visibility !== 'hidden' && style.display !== 'none';
 }

--- a/packages/providers/inpage-providers-hub/src/connectButtonHack/utils/utilsDomNodes.ts
+++ b/packages/providers/inpage-providers-hub/src/connectButtonHack/utils/utilsDomNodes.ts
@@ -50,7 +50,15 @@ function createElementFromHTML(htmlString: string) {
   return div.firstChild || '';
 }
 
-function findTextNode(container: string | HTMLElement, text: RegExp | string) {
+/**
+ * @description:
+ * only find the first text node match the text
+ */
+function findTextNode(
+  container: string | HTMLElement,
+  text: RegExp | string,
+  type: 'all' | 'first' = 'first',
+): Text | Text[] | undefined | null {
   const containerEle =
     typeof container === 'string' ? document.querySelector(container) : container;
   if (!containerEle) {
@@ -58,15 +66,26 @@ function findTextNode(container: string | HTMLElement, text: RegExp | string) {
   }
   const walker = document.createTreeWalker(containerEle, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
-      if (!node.nodeValue) {
+      if (!node.nodeValue || node.parentElement instanceof SVGElement) {
         return NodeFilter.FILTER_SKIP;
       }
-      return (typeof text === 'string' ? node.nodeValue === text : text.test(node.nodeValue))
+      return (
+        typeof text === 'string'
+          ? node.nodeValue.trim() === text.trim()
+          : text.test(node.nodeValue.trim())
+      )
         ? NodeFilter.FILTER_ACCEPT
         : NodeFilter.FILTER_SKIP;
     },
   });
-  return walker.nextNode();
+  if (type === 'all') {
+    const textNodes: Text[] = [];
+    while (walker.nextNode()) {
+      textNodes.push(walker.currentNode as Text);
+    }
+    return textNodes;
+  }
+  return walker.nextNode() as Text | null;
 }
 
 export default {


### PR DESCRIPTION
q: 使用container自动查找时 选中到错误的icon和text怎么办？
a: 
- 选中到错误的元素只会发生网站的结构和内容被修改后
- 使用完全用选择器直接指定icon和text，在网站修改后也可能选中到错误的元素。所以这个问题无法完全避免。
- 发生概率很小。
    - 因为container 会优先选中wallet button或者wallet button list. 
    - 如果container选弹窗modal也只选带有‘connect wallet’标题的弹窗。
    - 选中的icon和text 需要满足，1. 名字匹配。2.非外链且可点击（那一定是站内交互）3.都只出现一次(排除隐藏节点等情况）4. icon大小限制 5. 其他还有必要添加限制？比如icon和name的距离、是否对齐等（目前去掉了这些限制）

q: 为什么不直接用selector指定icon或者text?
a: 
   - 实际上，如果有唯一且稳定的选择器可以指定icon和text，会优先通过findIconAndName方法优先使用selector来指定icon和text
  - 通过container容器来模糊查找icon和text，只推荐用到没有稳定的选择器可用的情况下。

q: 为什么要用container进行自动查找：
a: 为了在网站修改后还可以选中到正确的元素，减少维护成本

q: 是否有既可以避免选中错误节点又可以避免选不到节点的方法？
a: 应该是没有的。因为网站的修改方式无法预知， 所以就可能导致选到错误的节点，或者一个节点都选不到。

q: 通过container自动查找是否使用selector直接指定更慢？
a: 我尝试肉眼对比过，看不出差异。如果替换后的按钮延迟出现，很可能是其他原因导致的。
       
