### PR TITLE
Change preload.js webpack config to support sandbox

### DIFF
--- a/packages/injected/webpack.config.cjs
+++ b/packages/injected/webpack.config.cjs
@@ -84,9 +84,12 @@ const extensionConfig = merge(commonConfig, {
 });
 
 const nativeConfig = merge(commonConfig, {
-  target: 'electron-preload',
+  target: 'web',
   entry: {
     injectedDesktop: './src/injectedDesktop.ts',
+  },
+  externals: {
+    electron: 'commonjs electron', // 将 Electron 标记为外部模块
   },
 });
 


### PR DESCRIPTION
To fix the issue caused by security config, sandbox, of app desktop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新构建配置以支持Web目标。
	- 引入外部模块配置，排除Electron依赖。
	- 为扩展配置添加了`buffer`模块的回退处理。

- **改进**
	- 自动加载`Buffer`模块，简化代码引用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->