### PR TITLE
Revert "Update id and name of the alephium provider"

### DIFF
--- a/packages/providers/onekey-alph-provider/src/OnekeyAlphProvider.ts
+++ b/packages/providers/onekey-alph-provider/src/OnekeyAlphProvider.ts
@@ -35,8 +35,8 @@ function isWalletEventMethodMatch({ method, name }: { method: string; name: stri
 }
 
 export class ProviderAlph extends InteractiveSignerProvider implements AlephiumWindowObject {
-  id = 'onekey';
-  name = 'OneKey';
+  id = 'alephium';
+  name = 'Alephium';
   icon = 'https://uni.onekey-asset.com/static/logo/onekey.png';
   version = '0.9.4';
   _accountInfo: Account | undefined;


### PR DESCRIPTION
This reverts commit 15a66e364f748dd1c77680fce7728982d09985d6.

As discussed, we need to use the `alephium` as wallet name and id for backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 提供者的标识符已更新为“alephium”和“Alephium”，反映了品牌重塑。
- **功能保持**
	- 现有的事件处理逻辑和连接管理方法保持不变，确保功能的连续性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->