### PR TITLE
feat: support aptos standrad signAndSendTx 1.0.0

### DIFF
--- a/packages/providers/inpage-providers-hub/src/injectWeb3Provider.ts
+++ b/packages/providers/inpage-providers-hub/src/injectWeb3Provider.ts
@@ -53,7 +53,7 @@ export type IWindowOneKeyHub = {
   btcwallet?: ProviderBtcWallet;
   alephium?: ProviderAlph;
   scdo?: ProviderScdo;
-  NEOLineN3?: NEOLineN3; 
+  NEOLineN3?: NEOLineN3;
   NEOLine?: NEOLineN3;
   $private?: ProviderPrivate;
   $walletInfo?: {
@@ -150,7 +150,7 @@ function injectWeb3Provider({
   const algorand = new ProviderAlgo({ bridge });
 
   const scdo = new ProviderScdo({ bridge });
-  
+
   const neo = new ProviderNeo({ bridge });
   NEOLineN3.instance = neo;
 
@@ -287,9 +287,9 @@ function injectWeb3Provider({
   if (checkWalletSwitchEnable()) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     registerAptosWallet(martian, {
-      name: 'Martian',
-      logo: WALLET_CONNECT_INFO.martian.icon as WalletIcon,
-      url: 'https://chrome.google.com/webstore/detail/martian-wallet/efbglgofoippbgcjepnhiblaibcnclgk',
+      name: 'Petra',
+      logo: WALLET_CONNECT_INFO.petra.icon as WalletIcon,
+      url: 'https://chromewebstore.google.com/detail/petra-aptos-wallet/ejjladinnckdgjemekebdpeokbikhfci',
     });
   }
 

--- a/packages/providers/onekey-aptos-provider/src/OnekeyAptosProvider.ts
+++ b/packages/providers/onekey-aptos-provider/src/OnekeyAptosProvider.ts
@@ -14,7 +14,7 @@ import type * as TypeUtils from './type-utils';
 import { IJsonRpcRequest } from '@onekeyfe/cross-inpage-provider-types';
 import { web3Errors } from '@onekeyfe/cross-inpage-provider-errors';
 import type { Types } from 'aptos';
-import type { AccountAuthenticator } from '@aptos-labs/ts-sdk';
+import type { AccountAuthenticator, PendingTransactionResponse } from '@aptos-labs/ts-sdk';
 import {
   AccountAuthenticatorEd25519,
   Ed25519PublicKey,
@@ -76,7 +76,10 @@ export type AptosRequest = {
     publicKey: string;
   }>;
 
+  // Standard Wallet V1.1.0
   'signAndSubmitTransactionV2': (params: string) => Promise<AptosSignAndSubmitTransactionOutput>;
+  // Standard Wallet V1.0.0
+  'signAndSubmitTransactionStandardV1': (params: string) => Promise<string>;
 };
 
 type JsBridgeRequest = {
@@ -124,6 +127,8 @@ export interface IProviderAptos extends ProviderAptosBase {
   signAndSubmitTransactionV2(
     params: AptosSignAndSubmitTransactionInput,
   ): Promise<AptosSignAndSubmitTransactionOutput>;
+
+  signAndSubmitTransactionStandardV1(params: string): Promise<PendingTransactionResponse>;
 
   /**
    * Sign message
@@ -349,6 +354,17 @@ class ProviderAptos extends ProviderAptosBase implements IProviderAptos {
       method: 'signAndSubmitTransactionV2',
       params: JSON.stringify(param),
     });
+  }
+
+  async signAndSubmitTransactionStandardV1(params: string): Promise<PendingTransactionResponse> {
+    const res = await this._callBridge({
+      method: 'signAndSubmitTransactionStandardV1',
+      params,
+    });
+    if (!res) throw web3Errors.provider.unauthorized();
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return JSON.parse(res);
   }
 
   async signMessageCompatible(

--- a/packages/providers/onekey-aptos-provider/src/serializer.ts
+++ b/packages/providers/onekey-aptos-provider/src/serializer.ts
@@ -99,6 +99,10 @@ export type TransactionPayloadV2SDK = InputScriptData | InputEntryFunctionData;
 export function serializeTransactionPayload(
   args: TransactionPayloadV1SDK | TransactionPayloadV2SDK,
 ) {
+  if (!args) {
+    throw new Error('Transaction payload cannot be undefined');
+  }
+
   const serializer = new Serializer();
   if ('type' in args || ('arguments' in args && 'type_arguments' in args)) {
     // Some Dapps do not pass the type parameter.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new transaction submission method for Aptos wallets, enabling compatibility with Standard Wallet V1.1.0.
  - Enhanced the transaction signing process to support an additional input format with raw transactions.
- **Bug Fixes**
  - Improved error handling for transaction payload serialization to prevent undefined payloads.
- **Tests**
  - Added tests for serializing and deserializing version 2 transaction payloads.
- **Chores**
  - Updated Aptos wallet registration metadata to use Petra instead of Martian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->