### PR TITLE
fix: add error handling for message sending in JsBridgeDesktopHost

### DIFF
--- a/packages/webview/src/JsBridgeDesktopHost.ts
+++ b/packages/webview/src/JsBridgeDesktopHost.ts
@@ -36,7 +36,11 @@ class JsBridgeDesktopHost extends JsBridgeBase {
         // this.webviewRef.current?.executeJavaScript?.(inpageReceiveCode);
 
         // *** use ipcRenderer.on instead
-        this.webviewRef.current?.send('JsBridgeDesktopHostToInjected', payloadStr);
+        try {
+          this.webviewRef.current?.send('JsBridgeDesktopHostToInjected', payloadStr);
+        } catch (error) {
+          appDebugLogger.webview('send', error);
+        }
       } else {
         throw new Error('JsBridgeDesktopHost executeJavaScript failed: webview ref not ready yet.');
       }


### PR DESCRIPTION
Implemented a try-catch block around the message sending logic to log errors when the webview reference is not ready, improving robustness in the JsBridgeDesktopHost class.