### PR TITLE
Unref setTimeout in JsBridgeBase to avoid keeping Node process alive

### DIFF
--- a/packages/core/src/CrossEventEmitter.ts
+++ b/packages/core/src/CrossEventEmitter.ts
@@ -18,9 +18,14 @@ function safeApply<T, A extends any[]>(
     Reflect.apply(handler, context, args);
   } catch (err) {
     // Throw error after timeout so as not to interrupt the stack
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       throw err;
     });
+    (
+      timeout as unknown as {
+        unref?: () => void;
+      }
+    ).unref?.();
   }
 }
 

--- a/packages/core/src/CrossEventEmitter.ts
+++ b/packages/core/src/CrossEventEmitter.ts
@@ -21,11 +21,7 @@ function safeApply<T, A extends any[]>(
     const timeout = setTimeout(() => {
       throw err;
     });
-    (
-      timeout as unknown as {
-        unref?: () => void;
-      }
-    ).unref?.();
+    (timeout as { unref?: () => void } | null)?.unref?.();
   }
 }
 

--- a/packages/core/src/JsBridgeBase.ts
+++ b/packages/core/src/JsBridgeBase.ts
@@ -353,11 +353,7 @@ abstract class JsBridgeBase extends CrossEventEmitter {
     const timeout = setTimeout(() => {
       this.rejectExpiredCallbacks();
     }, this.callbacksExpireTimeout);
-    (
-      timeout as unknown as {
-        unref?: () => void;
-      }
-    ).unref?.();
+    (timeout as { unref?: () => void } | null)?.unref?.();
   }
 
   clearCallbackCache(id: number | string) {

--- a/packages/core/src/JsBridgeBase.ts
+++ b/packages/core/src/JsBridgeBase.ts
@@ -350,9 +350,14 @@ abstract class JsBridgeBase extends CrossEventEmitter {
         }
       }
     }
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       this.rejectExpiredCallbacks();
     }, this.callbacksExpireTimeout);
+    (
+      timeout as unknown as {
+        unref?: () => void;
+      }
+    ).unref?.();
   }
 
   clearCallbackCache(id: number | string) {

--- a/packages/core/src/ProviderBase.ts
+++ b/packages/core/src/ProviderBase.ts
@@ -61,11 +61,7 @@ abstract class ProviderBase extends CrossEventEmitter {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       this.bridge.attachProviderInstance(this as any);
     }, 0);
-    (
-      timeout as unknown as {
-        unref?: () => void;
-      }
-    ).unref?.();
+    (timeout as { unref?: () => void } | null)?.unref?.();
     // call sendSiteMetadataDomReady/getConnectWalletInfo in ProviderPrivate, dont need here
     // void this.sendSiteMetadataDomReady();
     // void this.getConnectWalletInfo();
@@ -100,11 +96,7 @@ abstract class ProviderBase extends CrossEventEmitter {
         console.error(`getConnectWalletInfo timeout: ${timeout}`);
         resolve(null);
       }, timeout);
-      (
-        timer as unknown as {
-          unref?: () => void;
-        }
-      ).unref?.();
+      (timer as { unref?: () => void } | null)?.unref?.();
       try {
         const result = (await this.bridgeRequest({
           method: METHODS.wallet_getConnectWalletInfo,

--- a/packages/core/src/ProviderBase.ts
+++ b/packages/core/src/ProviderBase.ts
@@ -57,10 +57,15 @@ abstract class ProviderBase extends CrossEventEmitter {
     // TODO init this.debugLogger first, and enable debug config after extension connect
     this.debugLogger = this.bridge?.debugLogger || fakeDebugLogger;
     this.bridge?.debugLogger?._attachExternalLogger(this.logger);
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       this.bridge.attachProviderInstance(this as any);
     }, 0);
+    (
+      timeout as unknown as {
+        unref?: () => void;
+      }
+    ).unref?.();
     // call sendSiteMetadataDomReady/getConnectWalletInfo in ProviderPrivate, dont need here
     // void this.sendSiteMetadataDomReady();
     // void this.getConnectWalletInfo();
@@ -95,6 +100,11 @@ abstract class ProviderBase extends CrossEventEmitter {
         console.error(`getConnectWalletInfo timeout: ${timeout}`);
         resolve(null);
       }, timeout);
+      (
+        timer as unknown as {
+          unref?: () => void;
+        }
+      ).unref?.();
       try {
         const result = (await this.bridgeRequest({
           method: METHODS.wallet_getConnectWalletInfo,


### PR DESCRIPTION
### Motivation
- Prevent the recurring `setTimeout` in `JsBridgeBase.rejectExpiredCallbacks` from keeping the Node.js event loop alive indefinitely when callbacks expire.

### Description
- Capture the `setTimeout` handle in a `timeout` variable and call `unref` (via a safe type cast) so the timer does not block process exit, while preserving the existing recursive expiration behavior.

### Testing
- Ran the project's automated test suite with `yarn test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d644f3f25c8332bd7ebc4eaadd820c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onekeyhq/cross-inpage-provider/pull/463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
