### PR TITLE
fix(example): replace @unisat/wallet-utils with bitcore-lib for BTC s…

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -77,6 +77,7 @@
     "@tonconnect/ui-react": "2.3.0-beta.4",
     "@uiw/react-codemirror": "^4.22.1",
     "@unisat/wallet-utils": "^1.0.0",
+    "bitcore-lib": "10.0.0",
     "@uniswap/default-token-list": "^12.23.0",
     "@walletconnect/core": "^2.13.0",
     "@walletconnect/sign-client": "^2.13.0",

--- a/packages/example/yarn.lock
+++ b/packages/example/yarn.lock
@@ -8433,6 +8433,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bigi@^1.1.0, bigi@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/bigi/-/bigi-1.4.2.tgz#9c665a95f88b8b08fc05cfd731f561859d725825"
+  integrity sha512-ddkU+dFIuEIW8lE7ZwdIAf2UPoM90eaprg5m3YXAVVTmKlqV/9BX4A2M8BOK2yOq6/VgZFVhK6QAxJebhlbhzw==
+
 bigint-buffer@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/bigint-buffer/-/bigint-buffer-1.1.5.tgz#d038f31c8e4534c1f8d0015209bf34b4fa6dd442"
@@ -8461,6 +8466,17 @@ bindings@^1.2.1, bindings@^1.3.0, bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
+
+bip-schnorr@=0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/bip-schnorr/-/bip-schnorr-0.6.4.tgz#6fde7f301fe6b207dbd05f8ec2caf08fa5a51d0d"
+  integrity sha512-dNKw7Lea8B0wMIN4OjEmOk/Z5qUGqoPDY0P2QttLqGk1hmDPytLWW8PR5Pb6Vxy6CprcdEgfJpOjUu+ONQveyg==
+  dependencies:
+    bigi "^1.4.2"
+    ecurve "^1.0.6"
+    js-sha256 "^0.9.0"
+    randombytes "^2.1.0"
+    safe-buffer "^5.2.1"
 
 bip174@^2.1.1:
   version "2.1.1"
@@ -8555,6 +8571,20 @@ bitcoinjs-message@^2.2.0:
     create-hash "^1.1.2"
     secp256k1 "^3.0.1"
     varuint-bitcoin "^1.0.1"
+
+bitcore-lib@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-10.0.0.tgz#d6071123191ff55998975abd0c84f972357c384c"
+  integrity sha512-++W17e9UFiDuoXD5d8w5f2i92ooC7TnLZTUzSTji9tJdwTIOeaz0/1ZScAYyVx/69fNLCTmhSrGhOj2Pv31iaw==
+  dependencies:
+    bech32 "=2.0.0"
+    bip-schnorr "=0.6.4"
+    bn.js "=4.11.8"
+    bs58 "^4.0.1"
+    buffer-compare "=1.1.1"
+    elliptic "^6.5.3"
+    inherits "=2.0.1"
+    lodash "^4.17.20"
 
 bitcore-lib@^10.0.0:
   version "10.7.0"
@@ -9865,6 +9895,14 @@ ecpair@^2.1.0:
     randombytes "^2.1.0"
     typeforce "^1.18.0"
     wif "^2.0.6"
+
+ecurve@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/ecurve/-/ecurve-1.0.6.tgz#dfdabbb7149f8d8b78816be5a7d5b83fcf6de797"
+  integrity sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==
+  dependencies:
+    bigi "^1.1.0"
+    safe-buffer "^5.0.1"
 
 ed2curve@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
…ign message verification

@unisat/wallet-utils uses `new bitcore.crypto.ECDSA()` which is no longer a constructor in bitcore-lib@10.7.0 (now a static-methods object), causing "ECDSA is not a constructor" when verifying BTC signed messages.