### PR TITLE
fix(example): import Buffer in Tron example for signMessageV2

### DIFF
--- a/packages/example/components/chains/tron/example.tsx
+++ b/packages/example/components/chains/tron/example.tsx
@@ -16,6 +16,7 @@ import { InputWithSave } from '../../InputWithSave';
 import { toast } from '../../ui/use-toast';
 import { ApiComboboxRef, ApiForm, ApiFormRef, ComboboxOption } from '../../ApiForm';
 import { okLinkRequest } from '../utils/OkLink';
+import { Buffer } from 'buffer';
 
 type ITokenOption = {
   type: string;


### PR DESCRIPTION
Browser environment does not expose Buffer globally, so calling Buffer.from on the Tron SignMessage V2 Array path threw "ReferenceError: Buffer is not defined". Import it from the 'buffer' package to restore the hex array signing flow.