### PR TITLE
feat: add SUI multi-recipient signing demo

### DIFF
--- a/.github/workflows/test-example-web-build.yml
+++ b/.github/workflows/test-example-web-build.yml
@@ -25,7 +25,8 @@ jobs:
         run: |
           yarn
           yarn bootstrap
-          yarn build
+          yarn bootstrap
+          NODE_ENV=production yarn build
 
       - name: Build Example
         run: |

--- a/packages/example/components/ApiActuator/ApiPayload.tsx
+++ b/packages/example/components/ApiActuator/ApiPayload.tsx
@@ -13,6 +13,7 @@ import { Button } from '../ui/button';
 import {
   ApiPayloadProvider,
   useApiDispatch,
+  useBroadcastResult,
   useRequest,
   useResult,
   useValidateResult,
@@ -45,6 +46,7 @@ function ApiPayloadContent({
   presupposeParams,
   onExecute,
   onValidate,
+  onBroadcast,
   onPresupposeParamChange,
   generateRequestFrom,
   onGenerateRequest,
@@ -77,6 +79,13 @@ function ApiPayloadContent({
               <ValidateResultDisplay />
             </>
           )}
+
+          {onBroadcast && (
+            <>
+              <ApiExecuteBroadcast onBroadcast={onBroadcast} />
+              <BroadcastResultDisplay />
+            </>
+          )}
         </div>
       </CardContent>
     </Card>
@@ -94,6 +103,7 @@ export function ApiPayload(props: IApiPayloadProps) {
 export type IApiExecuteProps = {
   allowCallWithoutProvider?: boolean;
   timeout?: number;
+  onBroadcast?: (request: string, result: string) => Promise<string> | string;
 } & IApiExecutor;
 
 interface IExecuteResult {
@@ -128,11 +138,18 @@ function ApiExecute({
     },
     [dispatch],
   );
+  const handleSetBroadcastResult = useCallback(
+    (newResult: string) => {
+      dispatch({ type: 'SET_BROADCAST_RESULT', payload: newResult });
+    },
+    [dispatch],
+  );
 
   const handleExecute = useCallback(async () => {
     setLoading(true);
     handleSetResult('Calling...');
     handleSetValidateResult('');
+    handleSetBroadcastResult('');
 
     try {
       const { result, error } = await Promise.race([
@@ -152,7 +169,14 @@ function ApiExecute({
       handleSetResult(`Error: ${typeof error === 'string' ? error : JSON.stringify(error)}`);
     }
     setLoading(false);
-  }, [execute, request, handleSetResult]);
+  }, [
+    execute,
+    request,
+    timeout,
+    handleSetResult,
+    handleSetValidateResult,
+    handleSetBroadcastResult,
+  ]);
 
   return (
     <Button
@@ -196,6 +220,52 @@ function ApiExecuteValidate({ onExecute, onValidate }: IApiExecuteProps) {
   );
 }
 
+function ApiExecuteBroadcast({
+  onBroadcast,
+  timeout = 5 * 60 * 1000,
+}: Pick<IApiExecuteProps, 'onBroadcast' | 'timeout'>) {
+  const request = useRequest();
+  const result = useResult();
+  const dispatch = useApiDispatch();
+
+  const [loading, setLoading] = useState(false);
+
+  const handleSetBroadcastResult = useCallback(
+    (newResult: string) => {
+      dispatch({ type: 'SET_BROADCAST_RESULT', payload: newResult });
+    },
+    [dispatch],
+  );
+
+  const handleBroadcast = useCallback(async () => {
+    if (!onBroadcast) {
+      return;
+    }
+    setLoading(true);
+    handleSetBroadcastResult('Broadcasting...');
+    try {
+      const broadcastResult = await Promise.race([
+        onBroadcast(request, result),
+        new Promise<string>((_, rej) =>
+          setTimeout(() => rej(`broadcast timeout ${timeout}ms`), timeout),
+        ),
+      ]);
+      handleSetBroadcastResult(broadcastResult);
+    } catch (error) {
+      handleSetBroadcastResult(
+        `Error: ${typeof error === 'string' ? error : JSON.stringify(error)}`,
+      );
+    }
+    setLoading(false);
+  }, [onBroadcast, request, result, timeout, handleSetBroadcastResult]);
+
+  return (
+    <Button loading={loading} disabled={!result || !onBroadcast} onClick={handleBroadcast}>
+      Broadcast
+    </Button>
+  );
+}
+
 function ExecuteResultDisplay() {
   const result = useResult();
 
@@ -206,4 +276,10 @@ function ValidateResultDisplay() {
   const validateResult = useValidateResult();
 
   return <ResultTextArea label="验证结果" content={validateResult} />;
+}
+
+function BroadcastResultDisplay() {
+  const broadcastResult = useBroadcastResult();
+
+  return <ResultTextArea label="广播结果" content={broadcastResult} />;
 }

--- a/packages/example/components/ApiActuator/ApiPayloadProvider.tsx
+++ b/packages/example/components/ApiActuator/ApiPayloadProvider.tsx
@@ -6,6 +6,7 @@ import { IPresupposeParam } from './PresupposeParamsSelector';
 const RequestContext = createContext<string>('');
 const ResultContext = createContext<string>('');
 const ValidateResultContext = createContext<string>('');
+const BroadcastResultContext = createContext<string>('');
 const CurrentParamIdContext = createContext<string>('');
 const PresupposeParamsContext = createContext<IPresupposeParam[] | undefined>(undefined);
 const DispatchContext = createContext<React.Dispatch<ApiPayloadAction> | null>(null);
@@ -14,6 +15,7 @@ type ApiPayloadAction =
   | { type: 'SET_REQUEST'; payload: string }
   | { type: 'SET_RESULT'; payload: string }
   | { type: 'SET_VALIDATE_RESULT'; payload: string }
+  | { type: 'SET_BROADCAST_RESULT'; payload: string }
   | { type: 'SET_CURRENT_PARAM_ID'; payload: string }
   | { type: 'SET_PRESUPPOSE_PARAMS'; payload: IPresupposeParam[] };
 
@@ -52,6 +54,8 @@ function apiPayloadReducer(state: ApiPayloadState, action: ApiPayloadAction): Ap
       return { ...state, result: tryFormatCompactJson(action.payload) };
     case 'SET_VALIDATE_RESULT':
       return { ...state, validateResult: tryFormatJson(action.payload) };
+    case 'SET_BROADCAST_RESULT':
+      return { ...state, broadcastResult: tryFormatJson(action.payload) };
     case 'SET_CURRENT_PARAM_ID':
       return { ...state, currentPurposeParamId: action.payload };
     case 'SET_PRESUPPOSE_PARAMS':
@@ -65,6 +69,7 @@ interface ApiPayloadState {
   request: string;
   result: string;
   validateResult: string;
+  broadcastResult: string;
   currentPurposeParamId: string;
   presupposeParams?: IPresupposeParam[];
 }
@@ -78,6 +83,7 @@ export function ApiPayloadProvider({ children }: IApiPayloadProviderProps) {
     request: '',
     result: '',
     validateResult: '',
+    broadcastResult: '',
     currentPurposeParamId: '',
   });
 
@@ -86,6 +92,7 @@ export function ApiPayloadProvider({ children }: IApiPayloadProviderProps) {
   const requestValue = useMemo(() => state.request, [state.request]);
   const resultValue = useMemo(() => state.result, [state.result]);
   const validateResultValue = useMemo(() => state.validateResult, [state.validateResult]);
+  const broadcastResultValue = useMemo(() => state.broadcastResult, [state.broadcastResult]);
   const currentParamIdValue = useMemo(
     () => state.currentPurposeParamId,
     [state.currentPurposeParamId],
@@ -97,11 +104,13 @@ export function ApiPayloadProvider({ children }: IApiPayloadProviderProps) {
       <RequestContext.Provider value={requestValue}>
         <ResultContext.Provider value={resultValue}>
           <ValidateResultContext.Provider value={validateResultValue}>
-            <CurrentParamIdContext.Provider value={currentParamIdValue}>
-              <PresupposeParamsContext.Provider value={presupposeParamsValue}>
-                {children}
-              </PresupposeParamsContext.Provider>
-            </CurrentParamIdContext.Provider>
+            <BroadcastResultContext.Provider value={broadcastResultValue}>
+              <CurrentParamIdContext.Provider value={currentParamIdValue}>
+                <PresupposeParamsContext.Provider value={presupposeParamsValue}>
+                  {children}
+                </PresupposeParamsContext.Provider>
+              </CurrentParamIdContext.Provider>
+            </BroadcastResultContext.Provider>
           </ValidateResultContext.Provider>
         </ResultContext.Provider>
       </RequestContext.Provider>
@@ -119,6 +128,7 @@ export function useApiPayload() {
     request: useContext(RequestContext),
     result: useContext(ResultContext),
     validateResult: useContext(ValidateResultContext),
+    broadcastResult: useContext(BroadcastResultContext),
     currentPurposeParamId: useContext(CurrentParamIdContext),
     presupposeParams: useContext(PresupposeParamsContext),
     dispatch,
@@ -128,6 +138,7 @@ export function useApiPayload() {
 export const useRequest = () => useContext(RequestContext);
 export const useResult = () => useContext(ResultContext);
 export const useValidateResult = () => useContext(ValidateResultContext);
+export const useBroadcastResult = () => useContext(BroadcastResultContext);
 export const useCurrentParamId = () => useContext(CurrentParamIdContext);
 export const usePresupposeParams = () => useContext(PresupposeParamsContext);
 export const useApiDispatch = () => {

--- a/packages/example/components/chains/aptosStandard/example.tsx
+++ b/packages/example/components/chains/aptosStandard/example.tsx
@@ -59,6 +59,21 @@ const MaxGasAMount = 10000;
 const TRANSFER_SCRIPT =
   "0xa11ceb0b0700000a0601000203020605080d071525083a40107a1f010200030201000104060c060c05030003060c0503083c53454c463e5f30046d61696e0d6170746f735f6163636f756e74087472616e73666572ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000000000000000000114636f6d70696c6174696f6e5f6d65746164617461090003322e3003322e31000001070b000b01010b020b03110002";
 
+function normalizeSafeAptosDemoRecipients(recipients: string[]) {
+  return recipients.map((recipient, index) => {
+    const trimmedRecipient = recipient.trim();
+    if (!AccountAddress.isValid({ input: trimmedRecipient }).valid) {
+      throw new Error(`Invalid Aptos recipient at index ${index}`);
+    }
+    const normalizedRecipient = AccountAddress.from(trimmedRecipient).toString();
+    const withoutPrefix = normalizedRecipient.replace(/^0x/, '');
+    if (/^0+$/.test(withoutPrefix)) {
+      throw new Error(`Unsafe zero Aptos recipient at index ${index}`);
+    }
+    return normalizedRecipient;
+  });
+}
+
 function MultiAgentTransactionFlow() {
   const { account, network, signTransaction, submitTransaction } = useStandardWallet();
 
@@ -531,6 +546,39 @@ function Example() {
                 options: options ? options : undefined,
               },
               asFeePayer,
+            });
+            return res;
+          }}
+        />
+        <ApiPayload
+          title="signTransaction (Multi Recipient)"
+          description="Builds one Aptos batch_transfer_coins transaction. Defaults to self-transfer recipients for safety; edit recipients to your own addresses when testing different To values."
+          presupposeParams={params.signMultiRecipientTransaction(account?.address.toString() ?? '')}
+          onExecute={async (request: string) => {
+            const { recipients, amount } = JSON.parse(request) as {
+              recipients: string[];
+              amount: number | string;
+            };
+            if (!Array.isArray(recipients) || recipients.length === 0) {
+              throw new Error('At least one recipient is required');
+            }
+            const safeRecipients = normalizeSafeAptosDemoRecipients(recipients);
+            const transferAmount = Number(amount);
+            if (!Number.isSafeInteger(transferAmount) || transferAmount <= 0) {
+              throw new Error('amount must be a positive safe integer in octas');
+            }
+            const res = await signTransaction({
+              transactionOrPayload: {
+                data: {
+                  type: 'entry_function_payload',
+                  function: '0x1::aptos_account::batch_transfer_coins',
+                  typeArguments: [APTOS_COIN],
+                  functionArguments: [
+                    safeRecipients,
+                    safeRecipients.map(() => transferAmount),
+                  ],
+                },
+              },
             });
             return res;
           }}

--- a/packages/example/components/chains/aptosStandard/params.ts
+++ b/packages/example/components/chains/aptosStandard/params.ts
@@ -75,6 +75,16 @@ export default {
       }),
     },
   ],
+  signMultiRecipientTransaction: (address: string) => [
+    {
+      id: 'signTransaction-multi-recipient-native',
+      name: 'batch transfer native coin',
+      value: JSON.stringify({
+        recipients: [address, address],
+        amount: 1,
+      }),
+    },
+  ],
   signAndSubmitTransaction: (address: string) => [
     {
       id: 'transaction-native-pure',

--- a/packages/example/components/chains/btc/example.tsx
+++ b/packages/example/components/chains/btc/example.tsx
@@ -241,6 +241,16 @@ export default function BTCExample() {
             return 'Dapp Example: 不支持的类型签字的验证';
           }}
         />
+        <ApiPayload
+          title="deriveContextHash"
+          description="Derive a deterministic context hash for the current BTC account"
+          presupposeParams={params.deriveContextHash}
+          onExecute={async (request: string) => {
+            const obj = JSON.parse(request) as { appName: string; context: string };
+            const res = await provider?.deriveContextHash(obj.appName, obj.context);
+            return res;
+          }}
+        />
       </ApiGroup>
 
       <ApiGroup title="Transaction">

--- a/packages/example/components/chains/btc/params.ts
+++ b/packages/example/components/chains/btc/params.ts
@@ -83,6 +83,16 @@ export default {
       }),
     },
   ],
+  deriveContextHash: [
+    {
+      id: 'deriveContextHash',
+      name: 'deriveContextHash',
+      value: JSON.stringify({
+        appName: 'test-app',
+        context: 'deadbeef',
+      }),
+    },
+  ],
   sendBitcoin: (address: string) => [
     {
       id: 'sendBitcoin',

--- a/packages/example/components/chains/btc/types.ts
+++ b/packages/example/components/chains/btc/types.ts
@@ -22,6 +22,7 @@ export interface IProviderApi {
   }>;
   getBitcoinUtxos(cursor?: number, size?: number): Promise<{ txid: string; vout: number }[]>;
   signMessage(msg: string, type: string): Promise<string>;
+  deriveContextHash(appName: string, context: string): Promise<string>;
   sendBitcoin(
     toAddress: string,
     satoshis: number,

--- a/packages/example/components/chains/suiStandard/example.tsx
+++ b/packages/example/components/chains/suiStandard/example.tsx
@@ -12,7 +12,7 @@ import { useWallet } from '../../../components/connect/WalletContext';
 import DappList from '../../../components/DAppList';
 import params from './params';
 import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
-import { SUI_TYPE_ARG, normalizeSuiAddress } from '@mysten/sui/utils';
+import { SUI_TYPE_ARG, isValidSuiAddress, normalizeSuiAddress } from '@mysten/sui/utils';
 import type { CoinStruct } from '@mysten/sui/client';
 import { bcs } from '@mysten/sui/bcs';
 
@@ -57,6 +57,46 @@ export function normalizeSuiCoinType(coinType: string): string {
     }
   }
   return coinType;
+}
+
+const UNSAFE_MULTI_RECIPIENT_DEMO_ADDRESSES = new Set([
+  '0x0000000000000000000000000000000000000000000000000000000000000000',
+  '0x1111111111111111111111111111111111111111111111111111111111111111',
+  '0x2222222222222222222222222222222222222222222222222222222222222222',
+]);
+
+function normalizeSafeDemoRecipients(recipients: string[]) {
+  return recipients.map((recipient, index) => {
+    const trimmedRecipient = recipient.trim();
+    if (!isValidSuiAddress(trimmedRecipient)) {
+      throw new Error(`Recipient ${index + 1} must be a full SUI address`);
+    }
+    const normalizedRecipient = normalizeSuiAddress(trimmedRecipient);
+    if (UNSAFE_MULTI_RECIPIENT_DEMO_ADDRESSES.has(normalizedRecipient)) {
+      throw new Error(`Recipient ${index + 1} is not safe for this demo`);
+    }
+    return normalizedRecipient;
+  });
+}
+
+function parseSignedSuiTransactionResult(result: string) {
+  const {
+    bytes,
+    transactionBlockBytes,
+    signature,
+  }: {
+    bytes?: string;
+    transactionBlockBytes?: string;
+    signature?: string;
+  } = JSON.parse(result);
+  const transactionBlock = transactionBlockBytes ?? bytes;
+  if (!transactionBlock) {
+    throw new Error('Missing signed transaction bytes');
+  }
+  if (!signature) {
+    throw new Error('Missing signature');
+  }
+  return { transactionBlock, signature };
 }
 
 function AssetInfoView({
@@ -237,6 +277,10 @@ function Example() {
 
   const signTransactionPresupposeParams = useMemo(() => {
     return params.signTransaction(currentAccount?.address ?? '');
+  }, [currentAccount?.address]);
+
+  const signMultiRecipientTransactionPresupposeParams = useMemo(() => {
+    return params.signMultiRecipientTransaction(currentAccount?.address ?? '');
   }, [currentAccount?.address]);
 
   const signTokenTransactionParams = useMemo(() => {
@@ -523,6 +567,83 @@ function Example() {
               signature,
             );
             return (currentAccount.address === publicKey.toSuiAddress()).toString();
+          }}
+        />
+
+        <ApiPayload
+          title="signTransactionBlock (Multi Recipient)"
+          description="Builds one SUI PTB with multiple TransferObjects commands. Defaults to self-transfer recipients for safety; edit recipients to your own addresses when testing different To values."
+          presupposeParams={signMultiRecipientTransactionPresupposeParams}
+          onExecute={async (request: string) => {
+            const {
+              from,
+              recipients,
+              amount,
+            }: {
+              from: string;
+              recipients: string[];
+              amount: number;
+            } = JSON.parse(request);
+
+            if (!from || !isValidSuiAddress(from)) {
+              throw new Error('Connect a SUI account before signing');
+            }
+            if (!Number.isSafeInteger(amount) || amount <= 0) {
+              throw new Error('Amount must be a positive integer in MIST');
+            }
+            if (!Array.isArray(recipients) || recipients.length === 0) {
+              throw new Error('At least one recipient is required');
+            }
+            const safeRecipients = normalizeSafeDemoRecipients(recipients);
+
+            const transfer = new Transaction();
+            const coins = transfer.splitCoins(
+              transfer.gas,
+              safeRecipients.map(() => amount),
+            );
+            safeRecipients.forEach((recipient, index) => {
+              const coin = coins[index];
+              if (!coin) {
+                throw new Error(`Missing split coin for recipient ${index}`);
+              }
+              transfer.transferObjects([coin], recipient);
+            });
+
+            const tx = await sponsorTransaction(
+              client,
+              from,
+              await transfer.build({
+                client,
+                onlyTransactionKind: true,
+              }),
+            );
+
+            const res: unknown = await signTransaction({
+              transaction: tx,
+              account: currentAccount,
+            });
+            return JSON.stringify(res);
+          }}
+          onValidate={async (_request: string, result: string) => {
+            const { transactionBlock, signature } = parseSignedSuiTransactionResult(result);
+            const publicKey = await verifyTransactionSignature(
+              Buffer.from(transactionBlock, 'base64'),
+              signature,
+            );
+
+            return (currentAccount.address === publicKey.toSuiAddress()).toString();
+          }}
+          onBroadcast={async (_request: string, result: string) => {
+            const { transactionBlock, signature } = parseSignedSuiTransactionResult(result);
+            const res = await client.executeTransactionBlock({
+              transactionBlock,
+              signature,
+              options: {
+                showEffects: true,
+                showEvents: true,
+              },
+            });
+            return JSON.stringify(res);
           }}
         />
 

--- a/packages/example/components/chains/suiStandard/params.ts
+++ b/packages/example/components/chains/suiStandard/params.ts
@@ -34,6 +34,17 @@ export default {
       }),
     },
   ],
+  signMultiRecipientTransaction: (address: string) => [
+    {
+      id: 'signTransaction-multi-recipient',
+      name: 'signTransaction Multi Recipient',
+      value: JSON.stringify({
+        from: address,
+        recipients: [address, address],
+        amount: 1,
+      }),
+    },
+  ],
   signTokenTransaction: (address: string) => [
     {
       id: 'signUSDCransaction',


### PR DESCRIPTION
## Summary
- Add a SUI Standard example for signing a PTB with multiple `TransferObjects` recipients.
- Add an optional `Broadcast` action to `ApiPayload` so signed transaction bytes can be executed after signing.
- Make the demo safe by default with self-transfer recipients, a 1 MIST amount, and guardrails for unsafe placeholder addresses.

## Context
This demo was added to reproduce and validate OneKey app-side SUI transaction parsing for multi-recipient PTBs. The app fix expects SUI transfer parsing to preserve every outgoing recipient, and the example needs to build a realistic transaction shape that signs first and can optionally broadcast for end-to-end verification.

## Changes Detail
- `components/chains/suiStandard/params.ts`: adds a multi-recipient preset that defaults to the connected account as both recipients.
- `components/chains/suiStandard/example.tsx`: builds one SUI PTB with multiple `transferObjects` commands, validates signed results from either `bytes` or `transactionBlockBytes`, and optionally broadcasts via `client.executeTransactionBlock`.
- `components/ApiActuator/ApiPayload.tsx`: adds a generic optional `Broadcast` button and result output for examples that provide `onBroadcast`.
- `components/ApiActuator/ApiPayloadProvider.tsx`: stores broadcast result state in the existing payload context.

## Risk Assessment
- **Risk Level**: Low
- **Affected Area**: Example app only
- **Risk Areas**: The generic `ApiPayload` component gains an optional action, but existing callers are unchanged unless they pass `onBroadcast`.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json`
- [x] `npx eslint components/ApiActuator/ApiPayload.tsx components/ApiActuator/ApiPayloadProvider.tsx components/chains/suiStandard/example.tsx components/chains/suiStandard/params.ts`
- [x] `git diff --check`
- [x] Opened `http://localhost:3002/suiStandard` and confirmed the reload loop was caused by two concurrent Next dev servers sharing `.next`, not this code path.