### PR TITLE
fix: harden bridge error reconstruction OK-61451

### DIFF
--- a/packages/core/src/JsBridgeBase.spec.ts
+++ b/packages/core/src/JsBridgeBase.spec.ts
@@ -174,14 +174,57 @@ describe('JsBridgeBase response error lifecycle', () => {
     }
   });
 
-  test('falls back, clears the callback, and ignores a duplicate response', async () => {
-    jest.spyOn(providerErrors, 'toNativeErrorObject').mockImplementationOnce(() => {
-      throw new Error('Error reconstruction failed');
+  test('keeps the native Error prototype when metadata contains unsafe keys', async () => {
+    const bridge = new TestBridge({ timeout: 1000 });
+    const requestPromise = bridge.request({ data: { method: 'test_method' } });
+    if (!requestPromise) {
+      throw new Error('Expected an asynchronous bridge request');
+    }
+    const rejectionPromise = requestPromise.catch((error: unknown) => error);
+    const requestPayload = JSON.parse(String(bridge.lastPayload));
+    const serializedError = JSON.parse(`{
+      "message": "Remote failure with unsafe metadata",
+      "className": "OneKeyLocalError",
+      "__proto__": { "polluted": true },
+      "constructor": { "name": "FakeError" },
+      "prototype": { "polluted": true }
+    }`);
+
+    bridge.receive(
+      {
+        id: requestPayload.id,
+        type: 'RESPONSE',
+        error: serializedError,
+      },
+      { origin: 'https://example.com', internal: true },
+    );
+
+    const rejectedError = await rejectionPromise;
+    expect(rejectedError).toBeInstanceOf(Error);
+    expect(Object.getPrototypeOf(rejectedError)).toBe(Error.prototype);
+    expect(rejectedError).toMatchObject({
+      message: 'Remote failure with unsafe metadata',
+      className: 'OneKeyLocalError',
     });
+    expect(Object.prototype.hasOwnProperty.call(rejectedError, '__proto__')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(rejectedError, 'constructor')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(rejectedError, 'prototype')).toBe(false);
+  });
+
+  test('falls back, clears the callback, and ignores a duplicate response', async () => {
+    const toNativeErrorObjectSpy = jest
+      .spyOn(providerErrors, 'toNativeErrorObject')
+      .mockImplementationOnce(() => {
+        throw new Error('Error reconstruction failed');
+      });
     const bridge = new TestBridge({ timeout: 1000 });
     const rejectCallbackSpy = jest.spyOn(bridge, 'rejectCallback');
     const clearCallbackSpy = jest.spyOn(bridge, 'clearCallbackCache');
     const requestPromise = bridge.request({ data: { method: 'test_method' } });
+    if (!requestPromise) {
+      throw new Error('Expected an asynchronous bridge request');
+    }
+    const rejectionPromise = requestPromise.catch((error: unknown) => error);
     const requestPayload = JSON.parse(String(bridge.lastPayload));
     const response = {
       id: requestPayload.id,
@@ -195,9 +238,15 @@ describe('JsBridgeBase response error lifecycle', () => {
     bridge.receive(response, { origin: 'https://example.com', internal: true });
     bridge.receive(response, { origin: 'https://example.com', internal: true });
 
-    await expect(requestPromise).rejects.toMatchObject({
+    const rejectedError = await rejectionPromise;
+    expect(toNativeErrorObjectSpy).toHaveBeenCalledTimes(1);
+    expect(rejectedError).toBeInstanceOf(Error);
+    expect(rejectedError).toMatchObject({
       message: 'Original remote message',
     });
+    expect(Object.prototype.hasOwnProperty.call(rejectedError, 'constructorName')).toBe(
+      false,
+    );
     expect(rejectCallbackSpy).toHaveBeenCalledTimes(1);
     expect(clearCallbackSpy).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/src/JsBridgeBase.spec.ts
+++ b/packages/core/src/JsBridgeBase.spec.ts
@@ -1,5 +1,7 @@
 jest.mock('lodash-es', () => require('lodash'));
 
+import * as providerErrors from '../../errors/src';
+
 import { JsBridgeBase } from './JsBridgeBase';
 
 class TestBridge extends JsBridgeBase {
@@ -89,5 +91,114 @@ describe('JsBridgeBase callback timeout lifecycle', () => {
     });
 
     expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('JsBridgeBase response error lifecycle', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('reconstructs an Error and preserves serialized metadata', async () => {
+    const bridge = new TestBridge({ timeout: 1000 });
+    const requestPromise = bridge.request({ data: { method: 'test_method' } });
+    const requestPayload = JSON.parse(String(bridge.lastPayload));
+
+    bridge.receive(
+      {
+        id: requestPayload.id,
+        type: 'RESPONSE',
+        error: {
+          constructorName: 'OneKeyLocalError',
+          name: 'OneKeyLocalError',
+          message: 'Remote failure',
+          code: 'REMOTE_FAILURE',
+          className: 'OneKeyLocalError',
+          autoToast: true,
+        },
+      },
+      { origin: 'https://example.com', internal: true },
+    );
+
+    await expect(requestPromise).rejects.toMatchObject({
+      constructorName: 'OneKeyLocalError',
+      name: 'OneKeyLocalError',
+      message: 'Remote failure',
+      code: 'REMOTE_FAILURE',
+      className: 'OneKeyLocalError',
+      autoToast: true,
+    });
+  });
+
+  test('rejects when one serialized metadata field cannot be restored', async () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(Error.prototype, 'constructorName');
+    Object.defineProperty(Error.prototype, 'constructorName', {
+      configurable: true,
+      value: 'NativeError',
+      writable: false,
+    });
+
+    try {
+      const bridge = new TestBridge({ timeout: 1000 });
+      const requestPromise = bridge.request({ data: { method: 'test_method' } });
+      const requestPayload = JSON.parse(String(bridge.lastPayload));
+
+      bridge.receive(
+        {
+          id: requestPayload.id,
+          type: 'RESPONSE',
+          error: {
+            constructorName: 'OneKeyLocalError',
+            message: 'Remote failure with protected metadata',
+            className: 'OneKeyLocalError',
+          },
+        },
+        { origin: 'https://example.com', internal: true },
+      );
+
+      await expect(requestPromise).rejects.toMatchObject({
+        message: 'Remote failure with protected metadata',
+        className: 'OneKeyLocalError',
+      });
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(Error.prototype, 'constructorName', originalDescriptor);
+      } else {
+        delete (Error.prototype as Error & { constructorName?: string }).constructorName;
+      }
+    }
+  });
+
+  test('falls back, clears the callback, and ignores a duplicate response', async () => {
+    jest.spyOn(providerErrors, 'toNativeErrorObject').mockImplementationOnce(() => {
+      throw new Error('Error reconstruction failed');
+    });
+    const bridge = new TestBridge({ timeout: 1000 });
+    const rejectCallbackSpy = jest.spyOn(bridge, 'rejectCallback');
+    const clearCallbackSpy = jest.spyOn(bridge, 'clearCallbackCache');
+    const requestPromise = bridge.request({ data: { method: 'test_method' } });
+    const requestPayload = JSON.parse(String(bridge.lastPayload));
+    const response = {
+      id: requestPayload.id,
+      type: 'RESPONSE' as const,
+      error: {
+        message: 'Original remote message',
+        constructorName: 'OneKeyLocalError',
+      },
+    };
+
+    bridge.receive(response, { origin: 'https://example.com', internal: true });
+    bridge.receive(response, { origin: 'https://example.com', internal: true });
+
+    await expect(requestPromise).rejects.toMatchObject({
+      message: 'Original remote message',
+    });
+    expect(rejectCallbackSpy).toHaveBeenCalledTimes(1);
+    expect(clearCallbackSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/JsBridgeBase.ts
+++ b/packages/core/src/JsBridgeBase.ts
@@ -41,6 +41,23 @@ function toPlainError(errorInfo: IErrorInfo) {
   };
 }
 
+function createFallbackError(error: unknown): Error {
+  let message = 'Unknown bridge error';
+  try {
+    if (typeof error === 'string') {
+      message = error;
+    } else if (error && typeof error === 'object') {
+      const remoteMessage = (error as { message?: unknown }).message;
+      if (typeof remoteMessage === 'string') {
+        message = remoteMessage;
+      }
+    }
+  } catch {
+    // Reading serialized error metadata is best-effort across runtime boundaries.
+  }
+  return new Error(message);
+}
+
 function isLegacyExtMessage(payload: unknown): boolean {
   const payloadObj = payload as { name: string };
   return (
@@ -325,6 +342,7 @@ abstract class JsBridgeBase extends CrossEventEmitter {
   }) {
     const callbackInfo = this.callbacks[id as number];
     if (callbackInfo) {
+      this.clearCallbackCache(id);
       if (method === 'reject') {
         if (callbackInfo.reject) {
           callbackInfo.reject(error);
@@ -336,7 +354,6 @@ abstract class JsBridgeBase extends CrossEventEmitter {
           callbackInfo.resolve(data);
         }
       }
-      this.clearCallbackCache(id);
     }
   }
 
@@ -463,17 +480,20 @@ abstract class JsBridgeBase extends CrossEventEmitter {
       }
       const callbackInfo = this.callbacks[id];
       if (callbackInfo) {
-        try {
-          if (error) {
-            const errorObject = toNativeErrorObject(error);
-            this.rejectCallback(id, errorObject);
-          } else {
-            this.resolveCallback(id, data);
+        if (error) {
+          let errorObject: Error;
+          try {
+            errorObject = toNativeErrorObject(error);
+          } catch {
+            errorObject = createFallbackError(error);
           }
-        } catch (error0) {
-          this.emit(BRIDGE_EVENTS.error, error0);
-        } finally {
-          // noop
+          this.rejectCallback(id, errorObject);
+        } else {
+          try {
+            this.resolveCallback(id, data);
+          } catch (error0) {
+            this.emit(BRIDGE_EVENTS.error, error0);
+          }
         }
       }
     } else if (type === IJsBridgeMessageTypes.REQUEST) {

--- a/packages/errors/src/utils.ts
+++ b/packages/errors/src/utils.ts
@@ -7,6 +7,11 @@ const FALLBACK_ERROR: SerializedWeb3RpcError = {
   code: FALLBACK_ERROR_CODE,
   message: getMessageFromCode(FALLBACK_ERROR_CODE),
 };
+const UNSAFE_ERROR_METADATA_KEYS = new Set([
+  '__proto__',
+  'prototype',
+  'constructor',
+]);
 
 export const JSON_RPC_SERVER_ERROR_MESSAGE = 'Unspecified server error.';
 
@@ -172,6 +177,9 @@ export function toNativeErrorObject(error: unknown) {
     return newError;
   }
   for (const key of keys) {
+    if (UNSAFE_ERROR_METADATA_KEYS.has(key)) {
+      continue;
+    }
     try {
       (newError as unknown as Record<string, unknown>)[key] = plainErrorObject[key];
     } catch {

--- a/packages/errors/src/utils.ts
+++ b/packages/errors/src/utils.ts
@@ -148,17 +148,35 @@ export function toNativeErrorObject(error: unknown) {
   if (error instanceof Error) {
     return error;
   }
-  const plainErrorObject = error as {
-    name: string;
-    stack: string;
-    message: string;
-    autoToast: boolean;
-  };
-  const newError = new Error(plainErrorObject.message);
-  const keys = Object.keys(plainErrorObject);
+  const plainErrorObject = error as Record<string, unknown> | null;
+  let message: string | undefined;
+  try {
+    if (typeof error === 'string') {
+      message = error;
+    } else if (typeof plainErrorObject?.message === 'string') {
+      message = plainErrorObject.message;
+    }
+  } catch {
+    // Reading serialized error metadata is best-effort across runtime boundaries.
+  }
+
+  const newError = new Error(message);
+  if (!plainErrorObject || typeof plainErrorObject !== 'object') {
+    return newError;
+  }
+
+  let keys: string[] = [];
+  try {
+    keys = Object.keys(plainErrorObject);
+  } catch {
+    return newError;
+  }
   for (const key of keys) {
-    (newError as unknown as Record<string, unknown>)[key] =
-      plainErrorObject[key as keyof typeof plainErrorObject];
+    try {
+      (newError as unknown as Record<string, unknown>)[key] = plainErrorObject[key];
+    } catch {
+      // Keep the usable Error when one metadata field cannot be restored.
+    }
   }
   return newError;
 }


### PR DESCRIPTION
## Jira

OK-61451

## Root cause

`JsBridgeBase.receive()` reconstructed a serialized remote error and rejected the pending callback inside the same `try` block. If `toNativeErrorObject()` or any metadata assignment threw, the catch path only emitted a bridge error. The pending Promise remained registered and could wait until timeout instead of rejecting immediately.

## Extension runtime boundary

The Extension UI (popup, side panel, or tab), MV3 background service worker, offscreen document, and injected/content-script contexts have separate JavaScript heaps. The hosted and injected bridge implementations all inherit the shared `@onekeyfe/cross-inpage-provider-core` `JsBridgeBase` implementation. Serialized fields such as `constructorName` are retained only as metadata; this change does not rely on restoring a prototype across runtimes.

## Fix

- Restore serialized error metadata on a best-effort, per-field basis.
- Ignore prototype-sensitive metadata keys so a serialized payload cannot replace the native `Error` prototype.
- Preserve the original remote message in a safe native `Error` fallback if reconstruction unexpectedly fails.
- Remove the pending callback before settling it, so the caller rejects immediately, the callback is cleaned up, and duplicate responses cannot settle it again.
- Keep the change scoped to the bridge implementation and focused regression tests; package versions are unchanged.

## Verification

- `yarn bootstrap` (twice, matching CI)
- `NODE_ENV=production yarn build`
- `yarn test packages/core/src/JsBridgeBase.spec.ts --runInBand` — 1 suite, 8 tests passed
- `yarn test --runInBand --silent` — 21 suites, 41 tests passed
- `yarn lint` — 0 errors (323 pre-existing warnings)
- `cd packages/injected && yarn lint:dist`
- `git diff --check`

## Follow-up

Package publication and the corresponding `app-monorepo` dependency update remain separate follow-up work after this fix is merged.
